### PR TITLE
Fix regex match/capture, updated to remove most extraneous whitespace

### DIFF
--- a/tasks/pi-config.yml
+++ b/tasks/pi-config.yml
@@ -12,12 +12,11 @@
     - regexp: '^dtparam=uart0'
       line: dtparam=uart0=on
 
-# TODO: This is not working currently. Remove that option if present.
 - name: Ensure serial port is available for GPS.
   ansible.builtin.replace:
     path: /boot/firmware/cmdline.txt
-    regexp: '^([\w](?!.*\b{{ item }}\b).*)$'
-    replace: '\1'
+    regexp: '^(.*)\b({{ item }})\b(\s+)?(.*)$'
+    replace: '\1 \4'
   register: modify_cmdline_txt
   with_items:
     - "console=serial0,115200"


### PR DESCRIPTION
This addresses the regex capture problem by ignoring failed matches as ansible will happily not make any changes if there's no match.

Otherwise, if there's a match, return everything but the {{ item }}  using referenced captures