### PR TITLE
Add BeagleBone Black PRU IEP-based PPS hardware timestamping project

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ An example configuration for a slave/client node is set up in `ptp-client-node.y
   - [Conor Robinson's Raspberry Pi NTP Server](https://conorrobinson.ie/raspberry-pi-ntp-server-part-6/)
   - [Jeff Geerling: Time Card mini for GPS and OXCO on Pi](https://www.jeffgeerling.com/blog/2023/time-card-mini-adds-pi-gps-and-oxco-your-pc)
   - [Raspberry Pi 5 Stratum 1 NTP Server with Uptronics GPS HAT](https://github.com/tiagofreire-pt/rpi_uputronics_stratum1_chrony/)
+- [BeagleBone Black PRU PPS (IEP hardware timestamping)](https://github.com/dniminenn/bbs-pps-pru)
 
 ## Other Time Resources I found Interesting
 


### PR DESCRIPTION
Adds a BeagleBone Black project using the PRU IEP for deterministic PPS edge capture on AM335x.

The approach moves PPS timestamping out of the Linux interrupt path and into the PRU realtime domain, reducing timestamp jitter from microsecond-scale to ~100 ns.
May be of interest to others exploring hardware-assisted timestamping or PTP on SBCs.

<img width="1339" height="540" alt="Screenshot_20260302-193827" src="https://github.com/user-attachments/assets/246a6425-33df-47bb-9646-88569b123621" />
